### PR TITLE
Moved cell to its own separate trait

### DIFF
--- a/src/board/cell.rs
+++ b/src/board/cell.rs
@@ -1,0 +1,5 @@
+use crate::Player;
+
+pub trait Cell {
+    fn owner(&self) -> Option<&Player>;
+}

--- a/src/board/inner.rs
+++ b/src/board/inner.rs
@@ -1,4 +1,4 @@
-use super::{Board, Player};
+use super::{Board, Player, cell::Cell};
 use std::fmt::Display;
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -22,10 +22,16 @@ impl InnerBoard {
     }
 }
 
-impl Board for InnerBoard {
-    fn get_cell_owner(&self, cell: usize) -> Option<&Player> {
+impl Board<Option<Player>> for InnerBoard {
+    fn get_cell(&self, cell: usize) -> &Option<Player> {
         debug_assert!(cell < 9);
-        self.cells[cell].as_ref()
+        &self.cells[cell]
+    }
+}
+
+impl super::cell::Cell for Option<Player> {
+    fn owner(&self) -> Option<&Player> {
+        self.as_ref()
     }
 }
 
@@ -55,7 +61,7 @@ impl Display for InnerBoard {
         for cell in 0..9 {
             result_str = result_str.replace(
                 char::from_digit(cell, 10).unwrap(),
-                (if let Some(player) = self.get_cell_owner(cell as usize) {
+                (if let Some(player) = self.get_cell(cell as usize).owner() {
                     player.into()
                 } else {
                     ' '

--- a/src/board/inner.rs
+++ b/src/board/inner.rs
@@ -1,5 +1,5 @@
+use super::{Board, Player};
 use std::fmt::Display;
-use super::{Player, Board};
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 /// The inner-most board in the game. All of its cells are either empty or belong to a player.
@@ -43,8 +43,7 @@ impl From<[Option<Player>; 9]> for InnerBoard {
 
 impl Display for InnerBoard {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        const TEMPLATE_STR: &str = 
-" 0 │ 1 │ 2 
+        const TEMPLATE_STR: &str = " 0 │ 1 │ 2 
 ———————————
  3 │ 4 │ 5 
 ———————————
@@ -54,7 +53,16 @@ impl Display for InnerBoard {
         let mut result_str = TEMPLATE_STR.to_string();
 
         for cell in 0..9 {
-            result_str = result_str.replace(char::from_digit(cell, 10).unwrap(), (if let Some(player) = self.get_cell_owner(cell as usize) {player.into()} else {' '}).to_string().as_str());
+            result_str = result_str.replace(
+                char::from_digit(cell, 10).unwrap(),
+                (if let Some(player) = self.get_cell_owner(cell as usize) {
+                    player.into()
+                } else {
+                    ' '
+                })
+                .to_string()
+                .as_str(),
+            );
         }
 
         write!(f, "{result_str}")
@@ -65,14 +73,14 @@ impl Display for InnerBoard {
 mod tests {
     use super::*;
     #[test]
-fn create_inner_board() {
-    assert_eq!(
-        InnerBoard::new(),
-        InnerBoard {
-            cells: [const { None }; 9]
-        }
-    )
-}
+    fn create_inner_board() {
+        assert_eq!(
+            InnerBoard::new(),
+            InnerBoard {
+                cells: [const { None }; 9]
+            }
+        )
+    }
     #[test]
     fn display_inner_board() {
         let board = InnerBoard::from([
@@ -87,12 +95,14 @@ fn create_inner_board() {
             None,
         ]);
 
-        assert_eq!(format!("{board}"), 
-" O │ X │   
+        assert_eq!(
+            format!("{board}"),
+            " O │ X │   
 ———————————
  X │ X │ X 
 ———————————
  O │   │   \
-        ");
+        "
+        );
     }
 }

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod tests;
 
-
 mod inner;
 pub mod recursive;
 
@@ -78,5 +77,3 @@ pub trait Board {
         BoardState::InProgress
     }
 }
-
-

--- a/src/board/recursive.rs
+++ b/src/board/recursive.rs
@@ -78,6 +78,18 @@ mod cell {
         }
     }
 
+    impl Cell for RecursiveCell {
+        fn owner(&self) -> Option<&crate::Player> {
+            match &self.state {
+                BoardState::InProgress => None,
+                BoardState::Over(result) => match result {
+                    BoardResult::Draw => None,
+                    BoardResult::Winner(player) => Some(player),
+                },
+            }
+        }
+    }
+
     impl From<InnerBoard> for RecursiveCell {
         fn from(value: InnerBoard) -> Self {
             Self {
@@ -96,18 +108,6 @@ mod cell {
     impl Default for RecursiveCell {
         fn default() -> Self {
             Self::new()
-        }
-    }
-
-    impl Cell for RecursiveCell {
-        fn owner(&self) -> Option<&crate::Player> {
-            match &self.state {
-                BoardState::InProgress => None,
-                BoardState::Over(result) => match result {
-                    BoardResult::Draw => None,
-                    BoardResult::Winner(player) => Some(player),
-                },
-            }
         }
     }
 }

--- a/src/board/recursive.rs
+++ b/src/board/recursive.rs
@@ -1,8 +1,9 @@
 use std::fmt::Display;
 
+
 use crate::{BoardResult, BoardState};
 
-use super::{Board, inner::InnerBoard};
+use super::{Board, inner::InnerBoard, cell::Cell};
 
 pub struct RecursiveBoard {
     cells: [cell::RecursiveCell; 9],
@@ -17,17 +18,9 @@ impl RecursiveBoard {
     }
 }
 
-impl Board for RecursiveBoard {
-    fn get_cell_owner(&self, cell: usize) -> Option<&crate::Player> {
-        let cell = &self.cells[cell];
-
-        match &cell.state {
-            BoardState::InProgress => None,
-            BoardState::Over(result) => match result {
-                BoardResult::Draw => None,
-                BoardResult::Winner(player) => Some(player),
-            },
-        }
+impl Board<cell::RecursiveCell> for RecursiveBoard {
+    fn get_cell(&self, cell: usize) -> &cell::RecursiveCell {
+        &self.cells[cell]
     }
 }
 
@@ -103,6 +96,18 @@ mod cell {
     impl Default for RecursiveCell {
         fn default() -> Self {
             Self::new()
+        }
+    }
+
+    impl Cell for RecursiveCell {
+        fn owner(&self) -> Option<&crate::Player> {
+            match &self.state {
+                BoardState::InProgress => None,
+                BoardState::Over(result) => match result {
+                    BoardResult::Draw => None,
+                    BoardResult::Winner(player) => Some(player),
+                },
+            }
         }
     }
 }

--- a/src/board/recursive.rs
+++ b/src/board/recursive.rs
@@ -2,17 +2,18 @@ use std::fmt::Display;
 
 use crate::{BoardResult, BoardState};
 
-use super::{inner::InnerBoard, Board};
+use super::{Board, inner::InnerBoard};
 
 pub struct RecursiveBoard {
-    cells: [cell::RecursiveCell; 9]
+    cells: [cell::RecursiveCell; 9],
 }
-
 
 impl RecursiveBoard {
     #[must_use]
     pub const fn new() -> Self {
-        Self { cells: [const {cell::RecursiveCell::new()}; 9] }
+        Self {
+            cells: [const { cell::RecursiveCell::new() }; 9],
+        }
     }
 }
 
@@ -24,15 +25,17 @@ impl Board for RecursiveBoard {
             BoardState::InProgress => None,
             BoardState::Over(result) => match result {
                 BoardResult::Draw => None,
-                BoardResult::Winner(player) => Some(player)
-            }
+                BoardResult::Winner(player) => Some(player),
+            },
         }
     }
 }
 
-impl From<[InnerBoard;9]> for RecursiveBoard {
-    fn from(value: [InnerBoard;9]) -> Self {
-        Self { cells: value.map(|board |cell::RecursiveCell::from(board)) }
+impl From<[InnerBoard; 9]> for RecursiveBoard {
+    fn from(value: [InnerBoard; 9]) -> Self {
+        Self {
+            cells: value.map(|board| cell::RecursiveCell::from(board)),
+        }
     }
 }
 
@@ -44,8 +47,7 @@ impl Default for RecursiveBoard {
 
 impl Display for RecursiveBoard {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        const TEMPLATE_STR: &str = 
-" 0 │ 1 │ 2 
+        const TEMPLATE_STR: &str = " 0 │ 1 │ 2 
 ———————————
  3 │ 4 │ 5 
 ———————————
@@ -54,7 +56,10 @@ impl Display for RecursiveBoard {
 
         let mut result_str = TEMPLATE_STR.to_string();
         for cell in 0..9 {
-            result_str = result_str.replace(char::from_digit(cell, 10).unwrap(), char::from(&self.cells[cell as usize]).to_string().as_str())
+            result_str = result_str.replace(
+                char::from_digit(cell, 10).unwrap(),
+                char::from(&self.cells[cell as usize]).to_string().as_str(),
+            )
         }
 
         write!(f, "{result_str}")
@@ -67,20 +72,25 @@ mod cell {
     #[derive(Debug, Clone)]
     pub(super) struct RecursiveCell {
         board: InnerBoard,
-        pub(super) state: BoardState
+        pub(super) state: BoardState,
     }
-    
+
     impl RecursiveCell {
         #[must_use]
         pub const fn new() -> Self {
-            Self { board: InnerBoard::new(), state: BoardState::InProgress }
+            Self {
+                board: InnerBoard::new(),
+                state: BoardState::InProgress,
+            }
         }
     }
 
-
     impl From<InnerBoard> for RecursiveCell {
         fn from(value: InnerBoard) -> Self {
-            Self { state: value.get_state(), board: value }
+            Self {
+                state: value.get_state(),
+                board: value,
+            }
         }
     }
 

--- a/src/board/tests.rs
+++ b/src/board/tests.rs
@@ -1,4 +1,4 @@
-use crate::board::{inner::*, *};
+use crate::board::{inner::*, cell::*, *};
 
 #[test]
 fn get_cell() {
@@ -14,9 +14,9 @@ fn get_cell() {
         None,
     ]);
 
-    assert_eq!(board.get_cell_owner(0), None);
-    assert_eq!(board.get_cell_owner(2), Some(&Player::Circle));
-    assert_eq!(board.get_cell_owner(4), Some(&Player::Cross))
+    assert_eq!(board.get_cell(0).owner(), None);
+    assert_eq!(board.get_cell(2).owner(), Some(&Player::Circle));
+    assert_eq!(board.get_cell(4).owner(), Some(&Player::Cross))
 }
 
 #[test]

--- a/src/board/tests.rs
+++ b/src/board/tests.rs
@@ -1,4 +1,4 @@
-use crate::board::{*, inner::*};
+use crate::board::{inner::*, *};
 
 #[test]
 fn get_cell() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ impl From<&BoardResult> for char {
     fn from(value: &BoardResult) -> Self {
         match value {
             BoardResult::Draw => '-',
-            BoardResult::Winner(player) => player.into()
+            BoardResult::Winner(player) => player.into(),
         }
     }
 }
@@ -45,7 +45,7 @@ impl From<&BoardState> for char {
     fn from(value: &BoardState) -> Self {
         match value {
             BoardState::InProgress => ' ',
-            BoardState::Over(result) => result.into()
+            BoardState::Over(result) => result.into(),
         }
     }
 }


### PR DESCRIPTION
Moved the concept of a Cell to its own separate trait. That way, RecursiveBoard and InnerBoard can both represent it in a more ergonomic way, and Board can be generic over it.