### PR TITLE
Removed the dyn overhead from the `Display` of `Boards`

### DIFF
--- a/src/board/inner.rs
+++ b/src/board/inner.rs
@@ -1,4 +1,4 @@
-use super::{Board, Player};
+use super::{Board, BoardDisplay, Player};
 use std::fmt::Display;
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -57,7 +57,7 @@ impl From<[Option<Player>; 9]> for InnerBoard {
 
 impl Display for InnerBoard {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        (self as &dyn Board<Option<Player>>).fmt(f)
+        <Self as BoardDisplay<_>>::fmt(self, f)
     }
 }
 

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -5,8 +5,6 @@ mod cell;
 mod inner;
 pub mod recursive;
 
-use std::fmt::Display;
-
 use crate::{BoardResult, BoardState, Player};
 
 /// The trait that represents a board. Allows to check for the states of cells, state of the board as a whole etc.
@@ -82,7 +80,10 @@ pub trait Board<T: cell::Cell> {
     }
 }
 
-impl<T: cell::Cell> Display for dyn Board<T> {
+trait BoardDisplay<T>: Board<T>
+where
+    T: cell::Cell,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         const TEMPLATE_STR: &str = " 0 │ 1 │ 2 
 ———————————
@@ -102,4 +103,11 @@ impl<T: cell::Cell> Display for dyn Board<T> {
 
         write!(f, "{result_str}")
     }
+}
+
+impl<B, C> BoardDisplay<C> for B
+where
+    B: Board<C>,
+    C: cell::Cell,
+{
 }

--- a/src/board/recursive.rs
+++ b/src/board/recursive.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use crate::{BoardResult, BoardState};
 
-use super::{Board, cell::Cell, inner::InnerBoard};
+use super::{Board, BoardDisplay, cell::Cell, inner::InnerBoard};
 pub use cell::RecursiveCell;
 
 pub struct RecursiveBoard {
@@ -40,7 +40,7 @@ impl Default for RecursiveBoard {
 
 impl Display for RecursiveBoard {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        (self as &dyn Board<RecursiveCell>).fmt(f)
+        <Self as BoardDisplay<_>>::fmt(self, f)
     }
 }
 


### PR DESCRIPTION
After the last update to create a common surface for `Display` of `Board`s and avoid redundant impls, we ended up having to cast to a trait object to actually `fmt` inside `Display`. Now, with the usage of `BoardDisplay`, we still avoid repeating code, but remove the `dyn` overhead.